### PR TITLE
API, STOMP 반환 데이터 추가 및 스터디, 스터디 멤버 서버 feign 연동

### DIFF
--- a/.kube/chat-configmap.yaml
+++ b/.kube/chat-configmap.yaml
@@ -19,3 +19,11 @@ data:
         generate-ddl: true
         show-sql: true
         open-in-view: false
+      cloud:
+        openfeign:
+          client:
+            config:
+              RemoteStudyMemberApiService:
+                url: http://backend-study-member-service:8080
+              RemoteStudyBackendService:
+                url: http://backend-study-service:8080

--- a/.kube/chat-deployment.yaml
+++ b/.kube/chat-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: backend-study-chat
-          image: jae0ne/studyhub-study-chat:0.1.7
+          image: jae0ne/studyhub-study-chat:0.1.8
           imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE

--- a/.kube/chat-deployment.yaml
+++ b/.kube/chat-deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: backend-study-chat
-          image: jae0ne/studyhub-study-chat:0.0.1
+          image: jae0ne/studyhub-study-chat:0.1.7
           imagePullPolicy: Always
           env:
             - name: SPRING_PROFILES_ACTIVE

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.studyhub'
-version = '0.1.7'
+version = '0.1.8'
 
 java {
     toolchain {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.studyhub'
-version = '0.1.6'
+version = '0.1.7'
 
 java {
     toolchain {

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 dependencyManagement {

--- a/src/main/java/com/studyhub/study_chat/StudyChatApplication.java
+++ b/src/main/java/com/studyhub/study_chat/StudyChatApplication.java
@@ -2,7 +2,9 @@ package com.studyhub.study_chat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication
 public class StudyChatApplication {
 

--- a/src/main/java/com/studyhub/study_chat/api/api/ApiChatController.java
+++ b/src/main/java/com/studyhub/study_chat/api/api/ApiChatController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
+@CrossOrigin
 @RestController
 @RequestMapping("/api/chat")
 @RequiredArgsConstructor
@@ -20,6 +21,6 @@ public class ApiChatController {
         @RequestParam(required = false) LocalDateTime threshold,
         @RequestParam(required = false, defaultValue = "50") Integer amount
     ) {
-        return ApiResponseDto.createOk(chatService.getHistory(studyId, threshold = threshold != null ? threshold : LocalDateTime.now(), amount));
+        return ApiResponseDto.createOk(chatService.getHistory(studyId, threshold != null ? threshold : LocalDateTime.now(), amount));
     }
 }

--- a/src/main/java/com/studyhub/study_chat/api/api/ApiChatController.java
+++ b/src/main/java/com/studyhub/study_chat/api/api/ApiChatController.java
@@ -1,6 +1,6 @@
 package com.studyhub.study_chat.api.api;
 
-import com.studyhub.study_chat.api.dto.ChatResponseDto.ChatHistory;
+import com.studyhub.study_chat.api.dto.ChatResponseDto.ChatHistoryResponse;
 import com.studyhub.study_chat.common.dto.ApiResponseDto;
 import com.studyhub.study_chat.service.ChatService;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,7 @@ public class ApiChatController {
     private final ChatService chatService;
 
     @GetMapping("/list/study/{studyId}")
-    public ApiResponseDto<ChatHistory> getHistory(
+    public ApiResponseDto<ChatHistoryResponse> getHistory(
         @PathVariable Long studyId,
         @RequestParam(required = false) LocalDateTime threshold,
         @RequestParam(required = false, defaultValue = "50") Integer amount

--- a/src/main/java/com/studyhub/study_chat/api/dto/ChatRequestDto.java
+++ b/src/main/java/com/studyhub/study_chat/api/dto/ChatRequestDto.java
@@ -8,15 +8,19 @@ public class ChatRequestDto {
     public record ChatMessageRequest(
         MessageType messageType,
         String content,
-        Long replyForChatMessageId
+        Long replyForChatMessageId,
+        String replyForChatMessageContent,
+        String replyForChatMessageAuthorName
     ) {
-        public ChatMessage toEntity(Long speakerId, Chat studyChat, ChatMessage replyForChatMessage) {
+        public ChatMessage toEntity(Long speakerId, Chat studyChat) {
             return ChatMessage.builder()
                 .studyChat(studyChat)
                 .content(content)
                 .speakerId(speakerId)
                 .messageType(messageType != null ? messageType : MessageType.USER_MESSAGE)
-                .replyFor(replyForChatMessage != null ? replyForChatMessage.getId() : null)
+                .replyForChatMessageId(replyForChatMessageId)
+                .replyForChatMessageContent(replyForChatMessageContent)
+                .replyForChatMessageAuthorName(replyForChatMessageAuthorName)
                 .build();
         }
     }

--- a/src/main/java/com/studyhub/study_chat/api/dto/ChatResponseDto.java
+++ b/src/main/java/com/studyhub/study_chat/api/dto/ChatResponseDto.java
@@ -46,7 +46,7 @@ public class ChatResponseDto {
     }
 
     public record StudyMemberInfoResponse(
-        String userId,
+        Long userId,
         String userName,
         String status,
         StudyRole role

--- a/src/main/java/com/studyhub/study_chat/api/dto/ChatResponseDto.java
+++ b/src/main/java/com/studyhub/study_chat/api/dto/ChatResponseDto.java
@@ -12,17 +12,17 @@ import java.util.Comparator;
 import java.util.Optional;
 
 public class ChatResponseDto {
-    public record ChatHistory(
+    public record ChatHistoryResponse(
         Long studyChatId,
-        Slice<ChatEvent> chatEvents,
-        LocalDateTime threshold
+        Slice<ChatMessageResponse> chatMessages,
+        LocalDateTime threshold // TODO 참여 사용자 정보 반환
     ) {
-        public static ChatHistory toDto(Long studyChatId, Slice<ChatMessage> chatMessageSlice, LocalDateTime prevThreshold) {
+        public static ChatHistoryResponse toDto(Long studyChatId, Slice<ChatMessage> chatMessageSlice, LocalDateTime prevThreshold) {
             Optional<ChatMessage> oldestMessage = chatMessageSlice.getContent().stream().min(Comparator.comparing(ChatMessage::getCreatedAt));
-            return new ChatHistory(
+            return new ChatHistoryResponse(
                 studyChatId,
                 new SliceImpl<>(
-                    chatMessageSlice.getContent().stream().map(ChatEvent::toDto).toList(),
+                    chatMessageSlice.getContent().stream().map(ChatMessageResponse::toDto).toList(),
                     chatMessageSlice.getPageable(),
                     chatMessageSlice.hasNext()
                 ),
@@ -31,20 +31,20 @@ public class ChatResponseDto {
         }
     }
 
-    public record ChatEvent(
+    public record ChatMessageResponse(
         MessageType eventType,
-        StudyChatMessageData data,
+        ChatMessageData data,
         LocalDateTime timestamp
     ) {
-        public static ChatEvent toDto(ChatMessage chatMessage) {
-            StudyChatMessageData content = switch (chatMessage.getMessageType()) {
-                case USER_MESSAGE -> UserMessageEventResponse.toDto(chatMessage);
-                case USER_REPLY -> UserReplyEventResponse.toDto(chatMessage);
+        public static ChatMessageResponse toDto(ChatMessage chatMessage) {
+            ChatMessageData content = switch (chatMessage.getMessageType()) {
+                case USER_MESSAGE -> UserMessageMessageResponse.toDto(chatMessage);
+                case USER_REPLY -> UserReplyMessageResponse.toDto(chatMessage);
                 case SYSTEM_STUDY_CREW_JOINED, SYSTEM_STUDY_CREW_QUITED ->
-                    SystemStudyCrewMoveEventResponse.toDto(chatMessage);
-                case SYSTEM_BOARD_CREATED -> SystemBoardCreatedEventResponse.toDto(chatMessage);
+                    SystemCrewMoveMessageResponse.toDto(chatMessage);
+                case SYSTEM_BOARD_CREATED -> SystemBoardCreatedMessageResponse.toDto(chatMessage);
             };
-            return new ChatEvent(
+            return new ChatMessageResponse(
                 chatMessage.getMessageType(),
                 content,
                 chatMessage.getCreatedAt()
@@ -54,26 +54,26 @@ public class ChatResponseDto {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "eventType")
     @JsonSubTypes({
-        @JsonSubTypes.Type(value = UserMessageEventResponse.class, name = "USER_MESSAGE"),
-        @JsonSubTypes.Type(value = UserReplyEventResponse.class, name = "USER_REPLY"),
-        @JsonSubTypes.Type(value = SystemStudyCrewMoveEventResponse.class, name = "SYSTEM_STUDY_CREW_JOINED"),
-        @JsonSubTypes.Type(value = SystemStudyCrewMoveEventResponse.class, name = "SYSTEM_STUDY_CREW_QUITED"),
-        @JsonSubTypes.Type(value = SystemBoardCreatedEventResponse.class, name = "SYSTEM_BOARD_CREATED"),
+        @JsonSubTypes.Type(value = UserMessageMessageResponse.class, name = "USER_MESSAGE"),
+        @JsonSubTypes.Type(value = UserReplyMessageResponse.class, name = "USER_REPLY"),
+        @JsonSubTypes.Type(value = SystemCrewMoveMessageResponse.class, name = "SYSTEM_STUDY_CREW_JOINED"),
+        @JsonSubTypes.Type(value = SystemCrewMoveMessageResponse.class, name = "SYSTEM_STUDY_CREW_QUITED"),
+        @JsonSubTypes.Type(value = SystemBoardCreatedMessageResponse.class, name = "SYSTEM_BOARD_CREATED"),
     })
-    public interface StudyChatMessageData {
+    public interface ChatMessageData {
         Long studyChatId();
 
         Long studyChatMessageId();
     }
 
-    public record UserMessageEventResponse(
+    public record UserMessageMessageResponse(
         Long studyChatId,
         Long studyChatMessageId,
         String content,
         Long speakerId
-    ) implements StudyChatMessageData {
-        public static UserMessageEventResponse toDto(ChatMessage chatMessage) {
-            return new UserMessageEventResponse(
+    ) implements ChatMessageData {
+        public static UserMessageMessageResponse toDto(ChatMessage chatMessage) {
+            return new UserMessageMessageResponse(
                 chatMessage.getStudyChat().getId(),
                 chatMessage.getId(),
                 chatMessage.getContent(),
@@ -82,46 +82,52 @@ public class ChatResponseDto {
         }
     }
 
-    public record UserReplyEventResponse(
+    public record UserReplyMessageResponse(
         Long studyChatId,
         Long studyChatMessageId,
         String content,
         Long speakerId,
-        Long replyForChatMessageId
-    ) implements StudyChatMessageData {
-        public static UserReplyEventResponse toDto(ChatMessage chatMessage) {
-            return new UserReplyEventResponse(
+        Long replyForChatMessageId,
+        String replyForChatMessageAuthorName,
+        String replyForChatMessageContent
+    ) implements ChatMessageData {
+        public static UserReplyMessageResponse toDto(ChatMessage chatMessage) {
+            return new UserReplyMessageResponse(
                 chatMessage.getStudyChat().getId(),
                 chatMessage.getId(),
                 chatMessage.getContent(),
                 chatMessage.getSpeakerId(),
-                chatMessage.getReplyFor()
+                chatMessage.getReplyForChatMessageId(),
+                chatMessage.getReplyForChatMessageAuthorName(),
+                chatMessage.getReplyForChatMessageContent()
             );
         }
     }
 
-    public record SystemStudyCrewMoveEventResponse(
+    public record SystemCrewMoveMessageResponse(
         Long studyChatId,
         Long studyChatMessageId,
-        Long speakerId
-    ) implements StudyChatMessageData {
-        public static SystemStudyCrewMoveEventResponse toDto(ChatMessage chatMessage) {
-            return new SystemStudyCrewMoveEventResponse(
+        Long userId,
+        String userName
+    ) implements ChatMessageData {
+        public static SystemCrewMoveMessageResponse toDto(ChatMessage chatMessage) {
+            return new SystemCrewMoveMessageResponse(
                 chatMessage.getStudyChat().getId(),
                 chatMessage.getId(),
-                chatMessage.getSpeakerId()
+                chatMessage.getSpeakerId(),
+                chatMessage.getContent()
             );
         }
     }
 
-    public record SystemBoardCreatedEventResponse(
+    public record SystemBoardCreatedMessageResponse(
         Long studyChatId,
         Long studyChatMessageId,
-        Long speakerId,
+        Long authorId,
         Long boardId
-    ) implements StudyChatMessageData {
-        public static SystemBoardCreatedEventResponse toDto(ChatMessage chatMessage) {
-            return new SystemBoardCreatedEventResponse(
+    ) implements ChatMessageData {
+        public static SystemBoardCreatedMessageResponse toDto(ChatMessage chatMessage) {
+            return new SystemBoardCreatedMessageResponse(
                 chatMessage.getStudyChat().getId(),
                 chatMessage.getId(),
                 chatMessage.getSpeakerId(),

--- a/src/main/java/com/studyhub/study_chat/common/exception/UnreachableError.java
+++ b/src/main/java/com/studyhub/study_chat/common/exception/UnreachableError.java
@@ -1,0 +1,8 @@
+package com.studyhub.study_chat.common.exception;
+
+public class UnreachableError extends ClientError {
+    public UnreachableError(String message) {
+        this.errorCode = "UnreachableError";
+        this.errorMessage = message;
+    }
+}

--- a/src/main/java/com/studyhub/study_chat/config/AsyncConfig.java
+++ b/src/main/java/com/studyhub/study_chat/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.studyhub.study_chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+}

--- a/src/main/java/com/studyhub/study_chat/config/WebSocketMessageBrokerConfig.java
+++ b/src/main/java/com/studyhub/study_chat/config/WebSocketMessageBrokerConfig.java
@@ -13,7 +13,7 @@ public class WebSocketMessageBrokerConfig implements WebSocketMessageBrokerConfi
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry
             .addEndpoint("/api/chat/stomp")
-//            .setAllowedOriginPatterns(allowedOrigins)
+            .setAllowedOriginPatterns("**")
             .withSockJS();
         WebSocketMessageBrokerConfigurer.super.registerStompEndpoints(registry);
     }

--- a/src/main/java/com/studyhub/study_chat/domain/ChatMessage.java
+++ b/src/main/java/com/studyhub/study_chat/domain/ChatMessage.java
@@ -32,8 +32,12 @@ public class ChatMessage {
     @Enumerated(EnumType.STRING)
     @Column(name = "message_type", nullable = false)
     private MessageType messageType;
-    @Column(name = "reply_for_chat_message_id")
-    private Long replyFor;
     @Column(name = "board_id")
     private Long boardId;
+    @Column(name = "reply_for_chat_message_id")
+    private Long replyForChatMessageId;
+    @Column(name = "reply_for_chat_message_author_name")
+    private String replyForChatMessageAuthorName;
+    @Column(name = "reply_for_chat_message_content", columnDefinition = "TEXT")
+    private String replyForChatMessageContent;
 }

--- a/src/main/java/com/studyhub/study_chat/event/consumer/KafkaMessageConsumer.java
+++ b/src/main/java/com/studyhub/study_chat/event/consumer/KafkaMessageConsumer.java
@@ -1,9 +1,10 @@
 package com.studyhub.study_chat.event.consumer;
 
-import com.studyhub.study_chat.api.dto.ChatResponseDto.ChatEvent;
 import com.studyhub.study_chat.event.event.Topic;
 import com.studyhub.study_chat.event.event.board.BoardEvent;
+import com.studyhub.study_chat.event.event.chat.ChatEvent;
 import com.studyhub.study_chat.event.event.study.StudyEvent;
+import com.studyhub.study_chat.event.event.studyMember.StudyMemberEvent;
 import com.studyhub.study_chat.service.ChatService;
 import com.studyhub.study_chat.service.ChatStompService;
 import lombok.RequiredArgsConstructor;
@@ -23,10 +24,10 @@ public class KafkaMessageConsumer {
     @KafkaListener(
         topics = Topic.CHAT,
         groupId = "studychat-#{T(java.util.UUID).randomUUID().toString()}",
-        properties = JsonDeserializer.VALUE_DEFAULT_TYPE + ":com.studyhub.study_chat.api.dto.ChatResponseDto.ChatEvent"
+        properties = JsonDeserializer.VALUE_DEFAULT_TYPE + ":com.studyhub.study_chat.event.event.chat.ChatEvent"
     )
     void listenChatEvent(ChatEvent event, Acknowledgment ack) {
-        log.info("event arrived : {}", event.toString());
+        log.info("chat event arrived : {}", event.toString());
         chatStompService.subscribeChat(event);
         ack.acknowledge();
     }
@@ -37,7 +38,18 @@ public class KafkaMessageConsumer {
         properties = JsonDeserializer.VALUE_DEFAULT_TYPE + ":com.studyhub.study_chat.event.event.study.StudyEvent"
     )
     void listenStudyEvent(StudyEvent event, Acknowledgment ack) {
-        log.info("event arrived : {}", event.toString());
+        log.info("study event arrived : {}", event.toString());
+        chatService.handleEvent(event);
+        ack.acknowledge();
+    }
+
+    @KafkaListener(
+        topics = Topic.STUDY_MEMBER,
+        groupId = "studychat",
+        properties = JsonDeserializer.VALUE_DEFAULT_TYPE + ":com.studyhub.study_chat.event.event.studyMember.StudyMemberEvent"
+    )
+    void listenStudyMemberEvent(StudyMemberEvent event, Acknowledgment ack) {
+        log.info("study member event arrived : {}", event.toString());
         chatService.handleEvent(event);
         ack.acknowledge();
     }
@@ -48,7 +60,7 @@ public class KafkaMessageConsumer {
         properties = JsonDeserializer.VALUE_DEFAULT_TYPE + ":com.studyhub.study_chat.event.event.board.BoardEvent"
     )
     void listenStudyEvent(BoardEvent event, Acknowledgment ack) {
-        log.info("event arrived : {}", event.toString());
+        log.info("board event arrived : {}", event.toString());
         chatService.handleEvent(event);
         ack.acknowledge();
     }

--- a/src/main/java/com/studyhub/study_chat/event/event/KafkaEvent.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/KafkaEvent.java
@@ -2,6 +2,7 @@ package com.studyhub.study_chat.event.event;
 
 import com.studyhub.study_chat.domain.Chat;
 import com.studyhub.study_chat.domain.ChatMessage;
+import com.studyhub.study_chat.event.event.chat.ChatEvent;
 
 import java.time.LocalDateTime;
 
@@ -13,4 +14,6 @@ public interface KafkaEvent {
     LocalDateTime timestamp();
 
     ChatMessage toChatMessage(Chat studyChat);
+
+    ChatEvent kafkaEventToChatEvent(ChatMessage chatMessage);
 }

--- a/src/main/java/com/studyhub/study_chat/event/event/Topic.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/Topic.java
@@ -1,7 +1,8 @@
 package com.studyhub.study_chat.event.event;
 
 public class Topic {
-    public static final String CHAT = "CHAT";
-    public static final String STUDY = "STUDY";
-    public static final String BOARD = "BOARD";
+    public static final String CHAT = "chat";
+    public static final String STUDY = "study";
+    public static final String STUDY_MEMBER = "study-member";
+    public static final String BOARD = "post-events";
 }

--- a/src/main/java/com/studyhub/study_chat/event/event/board/BoardEvent.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/board/BoardEvent.java
@@ -3,11 +3,14 @@ package com.studyhub.study_chat.event.event.board;
 import com.studyhub.study_chat.common.exception.NotFound;
 import com.studyhub.study_chat.domain.Chat;
 import com.studyhub.study_chat.domain.ChatMessage;
-import com.studyhub.study_chat.domain.MessageType;
 import com.studyhub.study_chat.event.event.KafkaEvent;
 import com.studyhub.study_chat.event.event.KafkaEventToChatMessage;
+import com.studyhub.study_chat.event.event.chat.ChatEvent;
+import com.studyhub.study_chat.event.event.chat.ChatEvent.SystemBoardCreatedEventResponse;
 
 import java.time.LocalDateTime;
+
+import static com.studyhub.study_chat.domain.MessageType.SYSTEM_BOARD_CREATED;
 
 public record BoardEvent(
     BoardEventType eventType,
@@ -15,17 +18,30 @@ public record BoardEvent(
     LocalDateTime timestamp
 ) implements KafkaEvent {
     public ChatMessage toChatMessage(Chat studyChat) {
-        switch (eventType) {
-            case BOARD_CREATED -> {
-                return ChatMessage.builder()
-                    .studyChat(studyChat)
-                    .speakerId(data.authorId)
-                    .messageType(MessageType.SYSTEM_BOARD_CREATED)
-                    .boardId(data.boardId)
-                    .build();
-            }
+        return switch (eventType) {
+            case BOARD_CREATED -> ChatMessage.builder()
+                .studyChat(studyChat)
+                .speakerId(data.authorId)
+                .messageType(SYSTEM_BOARD_CREATED)
+                .boardId(data.boardId)
+                .build();
             default -> throw new NotFound("처리되지 않은 이벤트가 발생했습니다.");
-        }
+        };
+    }
+
+    public ChatEvent kafkaEventToChatEvent(ChatMessage chatMessage) {
+        return switch (eventType) {
+            case BOARD_CREATED -> new ChatEvent(
+                SYSTEM_BOARD_CREATED,
+                new SystemBoardCreatedEventResponse(
+                    chatMessage.getStudyChat().getId(),
+                    chatMessage.getId(),
+                    data.authorId,
+                    data.boardId
+                ),
+                chatMessage.getCreatedAt()
+            );
+        };
     }
 
     public record BoardEventData(

--- a/src/main/java/com/studyhub/study_chat/event/event/chat/ChatEvent.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/chat/ChatEvent.java
@@ -1,0 +1,129 @@
+package com.studyhub.study_chat.event.event.chat;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.studyhub.study_chat.common.exception.BadParameter;
+import com.studyhub.study_chat.common.exception.UnreachableError;
+import com.studyhub.study_chat.domain.Chat;
+import com.studyhub.study_chat.domain.ChatMessage;
+import com.studyhub.study_chat.domain.MessageType;
+import com.studyhub.study_chat.event.event.KafkaEvent;
+import com.studyhub.study_chat.event.event.KafkaEventToChatMessage;
+import com.studyhub.study_chat.event.event.studyMember.StudyRole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+
+public record ChatEvent(
+    MessageType eventType,
+    ChatEventData data,
+    LocalDateTime timestamp
+) implements KafkaEvent {
+    private static final Logger log = LoggerFactory.getLogger(ChatEvent.class);
+
+    public static ChatEvent toChatEvent(ChatMessage chatMessage) {
+        ChatEventData content = switch (chatMessage.getMessageType()) {
+            case USER_MESSAGE -> UserEventEventResponse.toDto(chatMessage);
+            case USER_REPLY -> UserReplyEventResponse.toDto(chatMessage);
+            default -> throw new BadParameter("시스템 메세지는 사용자가 생성할 수 없습니다.");
+        };
+        return new ChatEvent(
+            chatMessage.getMessageType(),
+            content,
+            chatMessage.getCreatedAt()
+        );
+    }
+
+    public ChatMessage toChatMessage(Chat studyChat) {
+        log.error("ChatEvent를 다시 publish해서는 안됩니다.", new UnreachableError(""));
+        return null;
+    }
+
+    public ChatEvent kafkaEventToChatEvent(ChatMessage chatMessage) {
+        return this;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "eventType")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = UserEventEventResponse.class, name = "USER_MESSAGE"),
+        @JsonSubTypes.Type(value = UserReplyEventResponse.class, name = "USER_REPLY"),
+        @JsonSubTypes.Type(value = SystemCrewMoveEventResponse.class, name = "SYSTEM_STUDY_CREW_JOINED"),
+        @JsonSubTypes.Type(value = SystemCrewMoveEventResponse.class, name = "SYSTEM_STUDY_CREW_QUITED"),
+        @JsonSubTypes.Type(value = SystemBoardCreatedEventResponse.class, name = "SYSTEM_BOARD_CREATED"),
+    })
+    public interface ChatEventData extends KafkaEventToChatMessage {
+        Long studyChatId();
+
+        Long studyChatMessageId();
+    }
+
+    public record UserEventEventResponse(
+        Long studyChatId,
+        Long studyChatMessageId,
+        String content,
+        Long speakerId
+    ) implements ChatEventData {
+        public static UserEventEventResponse toDto(ChatMessage chatMessage) {
+            return new UserEventEventResponse(
+                chatMessage.getStudyChat().getId(),
+                chatMessage.getId(),
+                chatMessage.getContent(),
+                chatMessage.getSpeakerId()
+            );
+        }
+
+        public Long studyId() {
+            throw new UnreachableError("ChatEvent는 studyId를 사용하지 않습니다.");
+        }
+    }
+
+    public record UserReplyEventResponse(
+        Long studyChatId,
+        Long studyChatMessageId,
+        String content,
+        Long speakerId,
+        Long replyForChatMessageId,
+        String replyForChatMessageAuthorName,
+        String replyForChatMessageContent
+    ) implements ChatEventData {
+        public static UserReplyEventResponse toDto(ChatMessage chatMessage) {
+            return new UserReplyEventResponse(
+                chatMessage.getStudyChat().getId(),
+                chatMessage.getId(),
+                chatMessage.getContent(),
+                chatMessage.getSpeakerId(),
+                chatMessage.getReplyForChatMessageId(),
+                chatMessage.getReplyForChatMessageAuthorName(),
+                chatMessage.getReplyForChatMessageContent()
+            );
+        }
+
+        public Long studyId() {
+            throw new UnreachableError("ChatEvent는 studyId를 사용하지 않습니다.");
+        }
+    }
+
+    public record SystemCrewMoveEventResponse(
+        Long studyChatId,
+        Long studyChatMessageId,
+        Long userId,
+        String userName,
+        StudyRole userRole
+    ) implements ChatEventData {
+        public Long studyId() {
+            throw new UnreachableError("ChatEvent는 studyId를 사용하지 않습니다.");
+        }
+    }
+
+    public record SystemBoardCreatedEventResponse(
+        Long studyChatId,
+        Long studyChatMessageId,
+        Long authorId,
+        Long boardId
+    ) implements ChatEventData {
+        public Long studyId() {
+            throw new UnreachableError("ChatEvent는 studyId를 사용하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/studyhub/study_chat/event/event/chat/ChatEvent.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/chat/ChatEvent.java
@@ -9,7 +9,7 @@ import com.studyhub.study_chat.domain.ChatMessage;
 import com.studyhub.study_chat.domain.MessageType;
 import com.studyhub.study_chat.event.event.KafkaEvent;
 import com.studyhub.study_chat.event.event.KafkaEventToChatMessage;
-import com.studyhub.study_chat.event.event.studyMember.StudyRole;
+import com.studyhub.study_chat.remote.studyMember.dto.StudyRole;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/studyhub/study_chat/event/event/study/StudyEvent.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/study/StudyEvent.java
@@ -1,11 +1,14 @@
 package com.studyhub.study_chat.event.event.study;
 
 import com.studyhub.study_chat.common.exception.NotFound;
+import com.studyhub.study_chat.common.exception.UnreachableError;
 import com.studyhub.study_chat.domain.Chat;
 import com.studyhub.study_chat.domain.ChatMessage;
-import com.studyhub.study_chat.domain.MessageType;
 import com.studyhub.study_chat.event.event.KafkaEvent;
 import com.studyhub.study_chat.event.event.KafkaEventToChatMessage;
+import com.studyhub.study_chat.event.event.chat.ChatEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
 
@@ -14,27 +17,21 @@ public record StudyEvent(
     StudyEventData data,
     LocalDateTime timestamp
 ) implements KafkaEvent {
+    private static final Logger log = LoggerFactory.getLogger(StudyEvent.class);
+
     public ChatMessage toChatMessage(Chat studyChat) {
         switch (eventType) {
-            case STUDY_CREATED -> {
+            case STUDY_CREATED, STUDY_DELETED -> {
                 return null;
-            }
-            case STUDY_CREW_JOINED -> {
-                return ChatMessage.builder()
-                    .studyChat(studyChat)
-                    .speakerId(data.userId)
-                    .messageType(MessageType.SYSTEM_STUDY_CREW_JOINED)
-                    .build();
-            }
-            case STUDY_CREW_QUITED -> {
-                return ChatMessage.builder()
-                    .studyChat(studyChat)
-                    .speakerId(data.userId)
-                    .messageType(MessageType.SYSTEM_STUDY_CREW_QUITED)
-                    .build();
             }
             default -> throw new NotFound("처리되지 않은 이벤트가 발생했습니다.");
         }
+    }
+
+    @Deprecated
+    public ChatEvent kafkaEventToChatEvent(ChatMessage chatMessage) {
+        log.error("StudyEvent로 ChatEvent를 만들수 없습니다.", new UnreachableError(""));
+        return null;
     }
 
     public record StudyEventData(

--- a/src/main/java/com/studyhub/study_chat/event/event/study/StudyEventType.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/study/StudyEventType.java
@@ -2,8 +2,6 @@ package com.studyhub.study_chat.event.event.study;
 
 public enum StudyEventType {
     STUDY_CREATED,
-    STUDY_CREW_JOINED,
-    STUDY_CREW_QUITED,
     STUDY_DELETED,
     ;
 }

--- a/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyMemberEvent.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyMemberEvent.java
@@ -1,0 +1,76 @@
+package com.studyhub.study_chat.event.event.studyMember;
+
+import com.studyhub.study_chat.common.exception.NotFound;
+import com.studyhub.study_chat.domain.Chat;
+import com.studyhub.study_chat.domain.ChatMessage;
+import com.studyhub.study_chat.domain.MessageType;
+import com.studyhub.study_chat.event.event.KafkaEvent;
+import com.studyhub.study_chat.event.event.KafkaEventToChatMessage;
+import com.studyhub.study_chat.event.event.chat.ChatEvent;
+import com.studyhub.study_chat.event.event.chat.ChatEvent.SystemCrewMoveEventResponse;
+
+import java.time.LocalDateTime;
+
+import static com.studyhub.study_chat.domain.MessageType.SYSTEM_STUDY_CREW_JOINED;
+import static com.studyhub.study_chat.domain.MessageType.SYSTEM_STUDY_CREW_QUITED;
+
+public record StudyMemberEvent(
+    StudyMemberEventType eventType,
+    StudyMemberEventData data,
+    LocalDateTime timestamp
+) implements KafkaEvent {
+    public ChatMessage toChatMessage(Chat studyChat) {
+        switch (eventType) {
+            case STUDY_CREW_JOINED -> {
+                return ChatMessage.builder()
+                    .studyChat(studyChat)
+                    .speakerId(data.userId)
+                    .messageType(SYSTEM_STUDY_CREW_JOINED)
+                    .build();
+            }
+            case STUDY_CREW_QUITED -> {
+                return ChatMessage.builder()
+                    .studyChat(studyChat)
+                    .speakerId(data.userId)
+                    .messageType(MessageType.SYSTEM_STUDY_CREW_QUITED)
+                    .build();
+            }
+            default -> throw new NotFound("처리되지 않은 이벤트가 발생했습니다.");
+        }
+    }
+
+    public ChatEvent kafkaEventToChatEvent(ChatMessage chatMessage) {
+        return switch (eventType) {
+            case STUDY_CREW_JOINED -> new ChatEvent(
+                SYSTEM_STUDY_CREW_JOINED,
+                new SystemCrewMoveEventResponse(
+                    chatMessage.getStudyChat().getId(),
+                    chatMessage.getId(),
+                    data.userId,
+                    data.userName,
+                    data.role
+                ),
+                timestamp
+            );
+            case STUDY_CREW_QUITED -> new ChatEvent(
+                SYSTEM_STUDY_CREW_QUITED,
+                new SystemCrewMoveEventResponse(
+                    chatMessage.getStudyChat().getId(),
+                    chatMessage.getId(),
+                    data.userId,
+                    data.userName,
+                    data.role
+                ),
+                timestamp
+            );
+        };
+    }
+
+    public record StudyMemberEventData(
+        Long studyId,
+        Long userId,
+        String userName,
+        StudyRole role
+    ) implements KafkaEventToChatMessage {
+    }
+}

--- a/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyMemberEvent.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyMemberEvent.java
@@ -8,6 +8,7 @@ import com.studyhub.study_chat.event.event.KafkaEvent;
 import com.studyhub.study_chat.event.event.KafkaEventToChatMessage;
 import com.studyhub.study_chat.event.event.chat.ChatEvent;
 import com.studyhub.study_chat.event.event.chat.ChatEvent.SystemCrewMoveEventResponse;
+import com.studyhub.study_chat.remote.studyMember.dto.StudyRole;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyMemberEvent.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyMemberEvent.java
@@ -27,6 +27,7 @@ public record StudyMemberEvent(
                     .studyChat(studyChat)
                     .speakerId(data.userId)
                     .messageType(SYSTEM_STUDY_CREW_JOINED)
+                    .content(data.userName)
                     .build();
             }
             case STUDY_CREW_QUITED -> {
@@ -34,6 +35,7 @@ public record StudyMemberEvent(
                     .studyChat(studyChat)
                     .speakerId(data.userId)
                     .messageType(MessageType.SYSTEM_STUDY_CREW_QUITED)
+                    .content(data.userName)
                     .build();
             }
             default -> throw new NotFound("처리되지 않은 이벤트가 발생했습니다.");

--- a/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyMemberEventType.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyMemberEventType.java
@@ -1,0 +1,7 @@
+package com.studyhub.study_chat.event.event.studyMember;
+
+public enum StudyMemberEventType {
+    STUDY_CREW_JOINED,
+    STUDY_CREW_QUITED,
+    ;
+}

--- a/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyRole.java
+++ b/src/main/java/com/studyhub/study_chat/event/event/studyMember/StudyRole.java
@@ -1,0 +1,7 @@
+package com.studyhub.study_chat.event.event.studyMember;
+
+public enum StudyRole {
+    MENTOR,
+    MENTEE,
+    ;
+}

--- a/src/main/java/com/studyhub/study_chat/event/producer/KafkaMessageProducer.java
+++ b/src/main/java/com/studyhub/study_chat/event/producer/KafkaMessageProducer.java
@@ -1,7 +1,7 @@
 package com.studyhub.study_chat.event.producer;
 
-import com.studyhub.study_chat.api.dto.ChatResponseDto.ChatEvent;
 import com.studyhub.study_chat.event.event.Topic;
+import com.studyhub.study_chat.event.event.chat.ChatEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ public class KafkaMessageProducer {
         kafkaTemplate.send(topic, message);
     }
 
-    public void sendChat(ChatEvent chatEvent) {
-        kafkaTemplate.send(Topic.CHAT, chatEvent);
+    public void sendChat(ChatEvent chatMessageResponse) {
+        kafkaTemplate.send(Topic.CHAT, chatMessageResponse);
     }
 }

--- a/src/main/java/com/studyhub/study_chat/remote/study/RemoteStudyBackendService.java
+++ b/src/main/java/com/studyhub/study_chat/remote/study/RemoteStudyBackendService.java
@@ -1,0 +1,16 @@
+package com.studyhub.study_chat.remote.study;
+
+import com.studyhub.study_chat.common.dto.ApiResponseDto;
+import com.studyhub.study_chat.remote.study.dto.InternalStudyInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+    name = "RemoteStudyBackendService",
+    path = "/backend/studies"
+)
+public interface RemoteStudyBackendService {
+    @GetMapping("/{studyId}")
+    ApiResponseDto<InternalStudyInfoResponse> getStudyInfoForInternalUse(@PathVariable Long studyId);
+}

--- a/src/main/java/com/studyhub/study_chat/remote/study/StudyService.java
+++ b/src/main/java/com/studyhub/study_chat/remote/study/StudyService.java
@@ -4,6 +4,7 @@ import com.studyhub.study_chat.common.dto.ApiResponseDto;
 import com.studyhub.study_chat.remote.study.dto.InternalStudyInfoResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.CompletableFuture;
@@ -14,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 public class StudyService {
     private final RemoteStudyBackendService remoteStudyBackendService;
 
+    @Async
     public CompletableFuture<InternalStudyInfoResponse> getStudyInfo(Long studyId) {
         ApiResponseDto<InternalStudyInfoResponse> infoForInternalUse = remoteStudyBackendService.getStudyInfoForInternalUse(studyId);
         if (!"OK".equals(infoForInternalUse.getCode())) {

--- a/src/main/java/com/studyhub/study_chat/remote/study/StudyService.java
+++ b/src/main/java/com/studyhub/study_chat/remote/study/StudyService.java
@@ -1,0 +1,25 @@
+package com.studyhub.study_chat.remote.study;
+
+import com.studyhub.study_chat.common.dto.ApiResponseDto;
+import com.studyhub.study_chat.remote.study.dto.InternalStudyInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudyService {
+    private final RemoteStudyBackendService remoteStudyBackendService;
+
+    public CompletableFuture<InternalStudyInfoResponse> getStudyInfo(Long studyId) {
+        ApiResponseDto<InternalStudyInfoResponse> infoForInternalUse = remoteStudyBackendService.getStudyInfoForInternalUse(studyId);
+        if (!"OK".equals(infoForInternalUse.getCode())) {
+            log.error("RemoteStudyBackendService: 스터디 정보를 불러올수 없습니다.");
+            return null;
+        }
+        return CompletableFuture.completedFuture(infoForInternalUse.getData());
+    }
+}

--- a/src/main/java/com/studyhub/study_chat/remote/study/dto/InternalStudyInfoResponse.java
+++ b/src/main/java/com/studyhub/study_chat/remote/study/dto/InternalStudyInfoResponse.java
@@ -1,0 +1,16 @@
+package com.studyhub.study_chat.remote.study.dto;
+
+import java.time.LocalDateTime;
+
+public record InternalStudyInfoResponse(
+    Long studyId,
+    String groupName,
+    String category,
+    String status,
+    int mentorCount,
+    int menteeCount,
+    int maxMentor,
+    int maxMentee,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/studyhub/study_chat/remote/studyMember/RemoteStudyMemberApiService.java
+++ b/src/main/java/com/studyhub/study_chat/remote/studyMember/RemoteStudyMemberApiService.java
@@ -1,0 +1,18 @@
+package com.studyhub.study_chat.remote.studyMember;
+
+import com.studyhub.study_chat.common.dto.ApiResponseDto;
+import com.studyhub.study_chat.remote.studyMember.dto.StudyMemberResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@FeignClient(
+    name = "RemoteStudyMemberApiService",
+    path = "/api/study-members"
+)
+public interface RemoteStudyMemberApiService {
+    @GetMapping("/members/{studyId}")
+    ApiResponseDto<List<StudyMemberResponseDto>> getMembers(@PathVariable Long studyId);
+}

--- a/src/main/java/com/studyhub/study_chat/remote/studyMember/StudyMemberService.java
+++ b/src/main/java/com/studyhub/study_chat/remote/studyMember/StudyMemberService.java
@@ -4,6 +4,7 @@ import com.studyhub.study_chat.common.dto.ApiResponseDto;
 import com.studyhub.study_chat.remote.studyMember.dto.StudyMemberResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,6 +16,7 @@ import java.util.concurrent.CompletableFuture;
 public class StudyMemberService {
     private final RemoteStudyMemberApiService remoteStudyMemberApiService;
 
+    @Async
     public CompletableFuture<List<StudyMemberResponseDto>> getStudyMembers(Long studyId) {
         ApiResponseDto<List<StudyMemberResponseDto>> studyMemberApiServiceMembers = remoteStudyMemberApiService.getMembers(studyId);
         if (!"OK".equals(studyMemberApiServiceMembers.getCode())) {

--- a/src/main/java/com/studyhub/study_chat/remote/studyMember/StudyMemberService.java
+++ b/src/main/java/com/studyhub/study_chat/remote/studyMember/StudyMemberService.java
@@ -1,0 +1,26 @@
+package com.studyhub.study_chat.remote.studyMember;
+
+import com.studyhub.study_chat.common.dto.ApiResponseDto;
+import com.studyhub.study_chat.remote.studyMember.dto.StudyMemberResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudyMemberService {
+    private final RemoteStudyMemberApiService remoteStudyMemberApiService;
+
+    public CompletableFuture<List<StudyMemberResponseDto>> getStudyMembers(Long studyId) {
+        ApiResponseDto<List<StudyMemberResponseDto>> studyMemberApiServiceMembers = remoteStudyMemberApiService.getMembers(studyId);
+        if (!"OK".equals(studyMemberApiServiceMembers.getCode())) {
+            log.error("RemoteStudyMemberApiService: 사용자 정보를 불러올수 없습니다.");
+            return null;
+        }
+        return CompletableFuture.completedFuture(studyMemberApiServiceMembers.getData());
+    }
+}

--- a/src/main/java/com/studyhub/study_chat/remote/studyMember/dto/StudyMemberResponseDto.java
+++ b/src/main/java/com/studyhub/study_chat/remote/studyMember/dto/StudyMemberResponseDto.java
@@ -1,0 +1,12 @@
+package com.studyhub.study_chat.remote.studyMember.dto;
+
+public record StudyMemberResponseDto(
+    Long id,
+    Long studyId,
+    String userId,
+    String userName,
+    String status,
+    StudyRole role,
+    String comment
+) {
+}

--- a/src/main/java/com/studyhub/study_chat/remote/studyMember/dto/StudyMemberResponseDto.java
+++ b/src/main/java/com/studyhub/study_chat/remote/studyMember/dto/StudyMemberResponseDto.java
@@ -3,7 +3,7 @@ package com.studyhub.study_chat.remote.studyMember.dto;
 public record StudyMemberResponseDto(
     Long id,
     Long studyId,
-    String userId,
+    Long userId,
     String userName,
     String status,
     StudyRole role,

--- a/src/main/java/com/studyhub/study_chat/remote/studyMember/dto/StudyRole.java
+++ b/src/main/java/com/studyhub/study_chat/remote/studyMember/dto/StudyRole.java
@@ -1,4 +1,4 @@
-package com.studyhub.study_chat.event.event.studyMember;
+package com.studyhub.study_chat.remote.studyMember.dto;
 
 public enum StudyRole {
     MENTOR,

--- a/src/main/java/com/studyhub/study_chat/service/ChatService.java
+++ b/src/main/java/com/studyhub/study_chat/service/ChatService.java
@@ -10,7 +10,12 @@ import com.studyhub.study_chat.domain.repository.ChatRepository;
 import com.studyhub.study_chat.event.event.KafkaEvent;
 import com.studyhub.study_chat.event.event.chat.ChatEvent;
 import com.studyhub.study_chat.event.event.study.StudyEvent;
+import com.studyhub.study_chat.remote.study.StudyService;
+import com.studyhub.study_chat.remote.study.dto.InternalStudyInfoResponse;
+import com.studyhub.study_chat.remote.studyMember.StudyMemberService;
+import com.studyhub.study_chat.remote.studyMember.dto.StudyMemberResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -19,16 +24,24 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static com.studyhub.study_chat.event.event.study.StudyEventType.STUDY_CREATED;
 import static com.studyhub.study_chat.event.event.study.StudyEventType.STUDY_DELETED;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatService {
     private final ChatRepository chatRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final StudyService studyService;
+    private final StudyMemberService studyMemberService;
 
     @Transactional
     public void publishChat(Long studyChatId, Long speakerId, ChatMessageRequest request) {
@@ -87,6 +100,36 @@ public class ChatService {
             threshold,
             PageRequest.of(0, amount, Sort.Direction.DESC, "createdAt")
         );
-        return ChatHistoryResponse.toDto(chat.getId(), chatMessageSlice, threshold);
+        StudyMetadata studyMetaData = getStudyMetaData(studyId, threshold);
+        return ChatHistoryResponse.toDto(chat.getId(), chatMessageSlice, threshold, studyMetaData.studyMembers, studyMetaData.studyInfo);
+    }
+
+    private StudyMetadata getStudyMetaData(Long studyId, LocalDateTime threshold) {
+        List<StudyMemberResponseDto> studyMembers = null;
+        InternalStudyInfoResponse studyInfo = null;
+        if (threshold != null) {
+            CompletableFuture<List<StudyMemberResponseDto>> studyMembersFuture = studyMemberService.getStudyMembers(studyId);
+            CompletableFuture<InternalStudyInfoResponse> studyInfoFutre = studyService.getStudyInfo(studyId);
+            CompletableFuture.allOf(studyMembersFuture, studyInfoFutre); // 작업 완료시까지 대기
+
+            try {
+                studyMembers = studyMembersFuture.get(2, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException ignore) {
+                log.error("RemoteStudyMemberApiService: 사용자 정보를 불러올수 없습니다.");
+            }
+
+            try {
+                studyInfo = studyInfoFutre.get(2, TimeUnit.SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException ignore) {
+                log.error("RemoteStudyBackendService: 스터디 정보를 불러올수 없습니다.");
+            }
+        }
+        return new StudyMetadata(studyMembers, studyInfo);
+    }
+
+    record StudyMetadata(
+        List<StudyMemberResponseDto> studyMembers,
+        InternalStudyInfoResponse studyInfo
+    ) {
     }
 }

--- a/src/main/java/com/studyhub/study_chat/service/ChatStompService.java
+++ b/src/main/java/com/studyhub/study_chat/service/ChatStompService.java
@@ -1,6 +1,6 @@
 package com.studyhub.study_chat.service;
 
-import com.studyhub.study_chat.api.dto.ChatResponseDto.ChatEvent;
+import com.studyhub.study_chat.event.event.chat.ChatEvent;
 import com.studyhub.study_chat.event.producer.KafkaMessageProducer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -23,3 +23,5 @@ spring:
         config:
           RemoteStudyMemberApiService:
             url: http://localhost:8082
+          RemoteStudyBackendService:
+            url: http://localhost:8083

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -17,3 +17,9 @@ spring:
     open-in-view: false
   kafka:
     bootstrap-servers: ${KAFKA_SERVER}
+  cloud:
+    openfeign:
+      client:
+        config:
+          RemoteStudyMemberApiService:
+            url: http://localhost:8082

--- a/src/test/java/com/studyhub/study_chat/kafkaMessageMaker.java
+++ b/src/test/java/com/studyhub/study_chat/kafkaMessageMaker.java
@@ -7,6 +7,10 @@ import com.studyhub.study_chat.event.event.board.BoardEventType;
 import com.studyhub.study_chat.event.event.study.StudyEvent;
 import com.studyhub.study_chat.event.event.study.StudyEvent.StudyEventData;
 import com.studyhub.study_chat.event.event.study.StudyEventType;
+import com.studyhub.study_chat.event.event.studyMember.StudyMemberEvent;
+import com.studyhub.study_chat.event.event.studyMember.StudyMemberEvent.StudyMemberEventData;
+import com.studyhub.study_chat.event.event.studyMember.StudyMemberEventType;
+import com.studyhub.study_chat.event.event.studyMember.StudyRole;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +40,7 @@ public class kafkaMessageMaker {
     @Test
     @Disabled
     public void studyCrewJoined() {
-        kafkaTemplate.send(Topic.STUDY, new StudyEvent(StudyEventType.STUDY_CREW_JOINED, new StudyEventData(1L, 1L), LocalDateTime.now()));
+        kafkaTemplate.send(Topic.STUDY_MEMBER, new StudyMemberEvent(StudyMemberEventType.STUDY_CREW_JOINED, new StudyMemberEventData(1L, 1L, "홍길동", StudyRole.MENTEE), LocalDateTime.now()));
     }
 
     @Test

--- a/src/test/java/com/studyhub/study_chat/kafkaMessageMaker.java
+++ b/src/test/java/com/studyhub/study_chat/kafkaMessageMaker.java
@@ -10,7 +10,7 @@ import com.studyhub.study_chat.event.event.study.StudyEventType;
 import com.studyhub.study_chat.event.event.studyMember.StudyMemberEvent;
 import com.studyhub.study_chat.event.event.studyMember.StudyMemberEvent.StudyMemberEventData;
 import com.studyhub.study_chat.event.event.studyMember.StudyMemberEventType;
-import com.studyhub.study_chat.event.event.studyMember.StudyRole;
+import com.studyhub.study_chat.remote.studyMember.dto.StudyRole;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
구현한 내용
- API, Socket 메시지 리스폰스 분리
- 답장 메시지 데이터 리퀘스트 dto, 엔티티에 추가
- 스터디 참여자 카프카 토픽 분리
- 스터디 멤버 서버 스터디원 정보 호출 API 연동
- 스터디 서버 스터디 정보 호출 API 연동
- 스터디 채팅 메타데이터 반환 로직 구현
  - 참여회원 정보
  - 간략한 스터디 정보